### PR TITLE
don't use a xml base (url) for the feed items

### DIFF
--- a/cccfeed.py
+++ b/cccfeed.py
@@ -47,7 +47,7 @@ def scrape(url):
         for link in entry.links:
             if link.type in app.config['CONTENT_TYPES']:
                 torrent_url = "%s.torrent" % link.url
-                out.add(entry.title, summary=entry.summary, url=torrent_url,
+                out.add(entry.title, summary=entry.summary, url=torrent_url, xml_base='',
                         updated=mktime(entry.updated), published=mktime(entry.published))
     return out.get_response()
 


### PR DESCRIPTION
This should fix the ruTorrent issue. 

[`xml_base`](http://werkzeug.pocoo.org/docs/0.11/contrib/atom/#werkzeug.contrib.atom.AtomFeed.add) defaults to the item url. ruTorrent does not implement xml:base properly. 
