### PR TITLE
raise an exception if mktime fails

### DIFF
--- a/cccfeed.py
+++ b/cccfeed.py
@@ -32,6 +32,7 @@ def mktime(source):
             return datetime.strptime(source.replace("+01:00", "+0100"), f)
         except ValueError:
             pass
+    raise Exception("cannot parse '%s'" % source)
 
 
 @cache.cached(timeout=300)


### PR DESCRIPTION
`mktime` failed on my pc. Meanwhile I know it is because I was using python 2.7, which does [not support %z](http://stackoverflow.com/questions/26165659/python-timezone-z-directive-for-datetime-strptime-not-available). This exception makes debugging easier.

Either merge this pull request, or my next. Not both.
