### PR TITLE
update for 33c3

### DIFF
--- a/cccfeed.py
+++ b/cccfeed.py
@@ -10,7 +10,7 @@ from time import mktime
 
 app = Flask(__name__)
 app.wsgi_app = ReverseProxied(app.wsgi_app)
-app.config['FEED_URL_BASE'] = "https://media.ccc.de/c/32c3/podcast/"
+app.config['FEED_URL_BASE'] = "https://media.ccc.de/c/33c3/podcast/"
 app.config['REQUEST_HEADERS'] = {
     "User-Agent": "CCC Torrent Feed Maker"
 }
@@ -48,8 +48,8 @@ def scrape(url):
 @app.route("/")
 def hello():
     feeds = {
-        'webm': ['webm (hd)', 'webm'],
-        'mp4': ['mp4 (hd)', 'mp4 (html5)', 'mp4'],
+        'webm': ['webm'],
+        'mp4': ['mp4'],
         'mp3': ['mp3'],
         'opus': ['opus']
     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>32C3 Atom Torrents</title>
+    <title>33C3 Atom Torrents</title>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='vendor/normalize.css/normalize.css') }}" />
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='vendor/milligram/dist/milligram.min.css') }}" />
     {% for feed, qualities in feeds.items() %}
       {% for quality in qualities %}
-        <link herf="{{ url_for('feed', name=quality, _external=True) }}" rel="alternate" title = "Podcast feed for {{ quality }} 32C3 torrents" type="application/rss+xml" />
+        <link herf="{{ url_for('feed', name=quality, _external=True) }}" rel="alternate" title = "Podcast feed for {{ quality }} 33C3 torrents" type="application/rss+xml" />
       {% endfor %}
     {% endfor %}
     <style type="text/css">
@@ -18,7 +18,7 @@
   </head>
   <body>
     <section class="container">
-      <h1>32C3 Torrent Feeds</h1>
+      <h1>33C3 Torrent Feeds</h1>
       <p>Available via <a href="https://cccfeeds.finn.io">clearnet</a> and as a <a href="http://32c3xt3uy7chnptn.onion">tor onion service</a>
     </section>
     <section class="container">


### PR DESCRIPTION
This updates the feeds from 32c3 into 33c3 (I did not update README.md)

I could not find separate SD/HD feeds. So currently there is just a single feed for both mp4 as webm.
Although audio feeds are working, the actual download does not work as the torrent trackers do not seem to allow it. I did not remove them, in case this will be fixed later.